### PR TITLE
Fix/ranking index out of bounds

### DIFF
--- a/src/main/java/br/com/nlw/events/controllers/SubscriptionController.java
+++ b/src/main/java/br/com/nlw/events/controllers/SubscriptionController.java
@@ -31,7 +31,12 @@ public class SubscriptionController {
     @Operation(summary = "Retorna o ranking geral de indicações para um evento específico", method = "GET")
     @GetMapping("/subscription/{prettyName}/ranking")
     public ResponseEntity<Object> generateRankingByEvent(@PathVariable String prettyName) {
-        return ResponseEntity.ok(subscriptionService.getCompleteRanking(prettyName).subList(0, 3));
+        var ranking = subscriptionService.getCompleteRanking(prettyName);
+        if (ranking.size() >= 3){
+            return ResponseEntity.ok(ranking.subList(0, 3));
+        }
+
+        return ResponseEntity.ok(ranking);
     }
 
     @Operation(summary = "Retorna a posição de um usuário específico no ranking de um evento", method = "GET")

--- a/src/main/java/br/com/nlw/events/services/SubscriptionService.java
+++ b/src/main/java/br/com/nlw/events/services/SubscriptionService.java
@@ -71,7 +71,12 @@ public class SubscriptionService {
             throw new EventNotFoundException("There is no ranking for this event: "+prettyName+".");
         }
 
-        return subscriptionRepository.generateRanking(event.getEventId());
+        var ranking = subscriptionRepository.generateRanking(event.getEventId());
+        if(ranking.isEmpty()) {
+            throw new EventNotFoundException("There is no ranking for this event: "+prettyName+".");
+        }
+
+        return ranking;
     }
 
     public SubscriptionRankingByUser getRankingByUser(String prettyName,Integer userId) {


### PR DESCRIPTION
## Descrição

Este PR corrige o erro `IndexOutOfBoundsException` que ocorria ao tentar gerar o ranking com menos de 3 participantes no endpoint `/subscription/{prettyName}/ranking`.

Além disso, foi tratada a situação em que o ranking está completamente vazio, retornando uma exceção personalizada (`EventNotFoundException`) com uma mensagem adequada.

## Alterações

- Ajusta o uso do método `subList()` para considerar dinamicamente o tamanho da lista e evitar estouro de índice
- Adiciona validação para retornar exceção quando o ranking estiver vazio (nenhuma pessoa indicada ainda)
- Garante que o endpoint não quebre com 0, 1, 2 ou mais participantes

Closes #1

